### PR TITLE
feat: track more files for changes

### DIFF
--- a/.github/workflows/packages.yaml
+++ b/.github/workflows/packages.yaml
@@ -55,7 +55,10 @@ jobs:
         id: changed-version
         uses: tj-actions/changed-files@v40
         with:
-          files: Dockerfile
+          files: |
+            Dockerfile
+            .github/workflows/packages.yaml
+            app/pgvectors.sql
 
       - name: Determine image push
         uses: actions/github-script@v7


### PR DESCRIPTION
The workflow is designed to only push to the registry on modified `Dockerfile`, which means the latest commit (which was a commit that update the base image of postgresql) before this PR didn't trigger a new package.
I think the `app/pgvector.sql` should also be tracked for the same reason.

This looks like a quick workaround, there should be a better way to do this actually but I don't have enough time to look into it.